### PR TITLE
implement additional new sources

### DIFF
--- a/backend/api_helper.py
+++ b/backend/api_helper.py
@@ -58,7 +58,10 @@ def get_news(limit):
     response = []
     for api in API_COLLECTION:
         headers = _set_headers(api)
-        print(f"running the {api['api_name']} api...")
+        print(f"running the {api['api_source']} api...")
+        if api["api_source"] == "newsapi":
+            limit = 40
+        print(api["listing_url"])
         result = requests.get(api["listing_url"].format(limit=limit),
                               headers=headers).json()
         if result:
@@ -80,7 +83,9 @@ def search_news(query, limit):
     response = []
     for api in API_COLLECTION:
         headers = _set_headers(api)
-        print(f"running the {api['api_name']} api...")
+        print(f"running the {api['api_source']} api...")
+        if api["api_source"] == "newsapi":
+            limit = 40
         result = requests.get(api["search_url"].format(query=query, limit=limit),
                               headers=headers).json()
         if result:

--- a/backend/external_api/models.py
+++ b/backend/external_api/models.py
@@ -7,19 +7,22 @@ class NewsBase:
     
     title: str,
     link: str,
-    source: str,
+    api_source: str,
     created_utc: str,
+    news_source: str,
     """
     def __init__(self, 
                 title: str,
                 link: str,
                 created_utc: str,
-                source: str,
+                api_source: str,
+                news_source: str,
     ):
         self.title: str = title
         self.link: str = link
         self.created_utc: str = created_utc
-        self.source: str = source
+        self.api_source: str = api_source
+        self.news_source: str = news_source
 
 
 class NewsList(NewsBase):

--- a/backend/external_api/news_api.py
+++ b/backend/external_api/news_api.py
@@ -5,6 +5,21 @@ import dateutil.parser as dp
 from backend.config import NEWS_API_KEY
 from backend.external_api.models import NewsBase
 
+# A comma-seperated string of identifiers for the news sources or blogs you want headlines from
+# https://newsapi.org/docs/endpoints/top-headlines
+SOURCES = """
+    'bbc-news', 'cnn', 'bloomberg', 'the-wall-street-journal', 'financial-times',
+    'axios', 'bbc-sport', 'cbc-news', 'hacker-news'
+"""
+def get_sources(sources):
+    sources = sources.replace(" ", "")
+    sources = sources.replace("\'", "")
+    sources = sources.replace("\"", "")
+    sources = sources.strip()
+    return sources
+
+CHOSEN_NEWS_SOURCES = get_sources(SOURCES)
+
 def newsapi_response_parser(results) -> List[NewsBase]:
     """
     :param results: JSON Object
@@ -13,7 +28,7 @@ def newsapi_response_parser(results) -> List[NewsBase]:
                 {
                     "title": "title of the news",
                     "link": "original link of the news source",
-                    "source":"your-api-name"
+                    "api_source":"your-api-name"
                 },
             ...
             ]
@@ -26,16 +41,19 @@ def newsapi_response_parser(results) -> List[NewsBase]:
             title=child["title"],
             link=child["url"],
             created_utc=created_utc,
-            source="newsapi",
+            news_source=child["source"]["name"],
+            api_source="newsapi",
         )
         response.append(news_base)
     # if nothing was added to the response list, append an empty NewsBase
     if not response:
+        print("no response found for newsapi...")
         empty_news_base = NewsBase(
             title="No items found!",
             link="",
             created_utc=datetime.today().timestamp(),
-            source="newsapi"
+            news_source="No source found",
+            api_source="newsapi"
         )
         response.append(empty_news_base)
     # sort the response by created_utc
@@ -46,12 +64,12 @@ def newsapi_response_parser(results) -> List[NewsBase]:
 # 'limit' and 'query' are provided when you call 
 # NEWS_API_MAPPING['listing_url'] or NEWS_API_MAPPING['search_url']
 NEWS_API_MAPPING = {
-    "api_name": "newsapi",
+    "api_source": "newsapi",
     "parser": newsapi_response_parser,
-    "listing_url": 'http://newsapi.org/v2/top-headlines?language=en&category=general&pageSize={limit}&page=1&' +
-                   'apiKey={api_key}'.format(api_key=NEWS_API_KEY),
+    "listing_url": 'http://newsapi.org/v2/top-headlines?language=en&pageSize={limit}&page=1&' +
+                   'sources={sources}&apiKey={api_key}'.format(api_key=NEWS_API_KEY, sources=CHOSEN_NEWS_SOURCES),
     "search_url": 'http://newsapi.org/v2/everything?language=en&q={query}&pageSize={limit}&page=1&' +
-                  'apiKey={api_key}'.format(api_key=NEWS_API_KEY),
+                  'sources={sources}&apiKey={api_key}'.format(api_key=NEWS_API_KEY, sources=CHOSEN_NEWS_SOURCES),
     "headers": "",
 }
 

--- a/backend/external_api/reddit_api.py
+++ b/backend/external_api/reddit_api.py
@@ -23,7 +23,7 @@ def reddit_response_parser(results) -> List[NewsBase]:
                 {
                     "title": "title of the news",
                     "link": "original link of the news source",
-                    "source": "your-api-name"
+                    "api_source": "your-api-name"
                     "created_utc": "date in epoc time"
                 },
             ...
@@ -35,7 +35,7 @@ def reddit_response_parser(results) -> List[NewsBase]:
             title=child["data"]["title"],
             link=child["data"]["url"],
             created_utc=child["data"]["created_utc"],
-            source="Reddit",
+            api_source="Reddit",
         )
         response.append(news_base)
     return response
@@ -52,7 +52,7 @@ def pushshift_reddit_response_parser(results) -> List[NewsBase]:
                 {
                     "title": "title of the news",
                     "link": "original link of the news source",
-                    "source": "your-api-name"
+                    "api_source": "your-api-name"
                     "created_utc": "date in epoc time"
                 },
             ...
@@ -64,7 +64,8 @@ def pushshift_reddit_response_parser(results) -> List[NewsBase]:
             title=child["title"],
             link=child["full_link"],
             created_utc=child["created_utc"],
-            source="Reddit",
+            news_source="Reddit",
+            api_source="Reddit",
         )
         response.append(news_base)
 
@@ -74,7 +75,8 @@ def pushshift_reddit_response_parser(results) -> List[NewsBase]:
             title="No items found!",
             link="",
             created_utc=datetime.today().timestamp(),
-            source="Reddit"
+            news_source="Reddit",
+            api_source="Reddit",
         )
         response.append(empty_news_base)
     return response
@@ -99,7 +101,7 @@ search_url = (base_url + "&"
 )
 
 REDDIT_API_MAPPING_V3 = {
-    "api_name": "Reddit",
+    "api_source": "Reddit",
     "parser": pushshift_reddit_response_parser,
     "listing_url": listing_url,
     "search_url": search_url,

--- a/frontend/src/components/NewsFeed.jsx
+++ b/frontend/src/components/NewsFeed.jsx
@@ -69,7 +69,7 @@ const setNewsItems = (news_data) => {
                 </Box>
                 <Box>
                     <Text mt={2} fontSize="sm">
-                        {article.source}: {timeConverter(article.created_utc)}
+                        {article.news_source}: {timeConverter(article.created_utc)}
                     </Text>
                 </Box>
             </Stack>


### PR DESCRIPTION
Using the NewsAPI, define specific news sources that we want to grab from. As a result, setting a fixed limit to 40 articles for the NewsAPI. 